### PR TITLE
Change graalvm flag to report exceptions

### DIFF
--- a/docs-examples/build.gradle
+++ b/docs-examples/build.gradle
@@ -19,7 +19,7 @@ subprojects { Project subproject ->
     }
 
     nativeImage {
-        args("-H:+TraceClassInitialization")
+        args("-H:+ReportExceptionStackTraces")
     }
 
 }


### PR DESCRIPTION
The previous one has changed in 20.3.0 and now it requires a list of classes to trace