### PR TITLE
Message mapping annotation

### DIFF
--- a/mqtt-core/src/main/java/io/micronaut/mqtt/annotation/Topic.java
+++ b/mqtt-core/src/main/java/io/micronaut/mqtt/annotation/Topic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/mqtt-core/src/main/java/io/micronaut/mqtt/annotation/Topic.java
+++ b/mqtt-core/src/main/java/io/micronaut/mqtt/annotation/Topic.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.mqtt.annotation;
 
+import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.messaging.annotation.MessageMapping;
 
 import java.lang.annotation.*;
 
@@ -39,6 +41,10 @@ import java.lang.annotation.*;
 @Bindable
 public @interface Topic {
 
+    /**
+     * @return The topic to subscribe to
+     */
+    @AliasFor(annotation = MessageMapping.class, member = "value")
     String value() default "";
 
     int qos() default 1;

--- a/mqttv3/src/test/groovy/io/micronaut/mqtt/annotation/V3TopicAnnotationSpec.groovy
+++ b/mqttv3/src/test/groovy/io/micronaut/mqtt/annotation/V3TopicAnnotationSpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.mqtt.annotation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
+import io.micronaut.messaging.annotation.MessageMapping
+import io.micronaut.mqtt.test.AbstractMQTTTest
+
+class V3TopicAnnotationSpec extends AbstractMQTTTest {
+
+    void "test that @Topic value aliases to @MessageMapping"() {
+        given:
+        ApplicationContext ctx = startContext("v3topicannotationtest": true)
+        def definition = ctx.getBeanDefinition(MySubscriber)
+
+        when:
+        def method = definition.getRequiredMethod("receive", String)
+        def annotationValue = method.getValue(MessageMapping, String[])
+
+        then:
+        annotationValue.isPresent()
+        annotationValue.get().contains 'test/topic1'
+    }
+
+
+    @Requires(property = "v3topicannotationtest", value = StringUtils.TRUE)
+    @MqttSubscriber
+    static class MySubscriber {
+
+        List<String> topics = []
+
+        @Topic("test/topic1")
+        void receive(String topic) {
+            topics.add(topic)
+        }
+    }
+
+}

--- a/mqttv5/src/test/groovy/io/micronaut/mqtt/annotation/V5TopicAnnotationSpec.groovy
+++ b/mqttv5/src/test/groovy/io/micronaut/mqtt/annotation/V5TopicAnnotationSpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.mqtt.annotation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
+import io.micronaut.messaging.annotation.MessageMapping
+import io.micronaut.mqtt.test.AbstractMQTTTest
+
+class V5TopicAnnotationSpec extends AbstractMQTTTest {
+
+    void "test that @Topic value aliases to @MessageMapping"() {
+        given:
+        ApplicationContext ctx = startContext("v5topicannotationtest": true)
+        def definition = ctx.getBeanDefinition(MySubscriber)
+
+        when:
+        def method = definition.getRequiredMethod("receive", String)
+        def annotationValue = method.getValue(MessageMapping, String[])
+
+        then:
+        annotationValue.isPresent()
+        annotationValue.get().contains 'test/topic1'
+    }
+
+
+    @Requires(property = "v5topicannotationtest", value = StringUtils.TRUE)
+    @MqttSubscriber
+    static class MySubscriber {
+
+        List<String> topics = []
+
+        @Topic("test/topic1")
+        void receive(String topic) {
+            topics.add(topic)
+        }
+    }
+
+}


### PR DESCRIPTION
The `@Topic` annotation's value is now an alias for `@MessageMapping`.