### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/mqttv3/src/main/resources/META-INF/native-image/io.micronaut.mqtt/mqttv3/native-image.properties
+++ b/mqttv3/src/main/resources/META-INF/native-image/io.micronaut.mqtt/mqttv3/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.mqtt.v3.client.health.$MqttHealthIndicator$Definition

--- a/mqttv5/src/main/resources/META-INF/native-image/io.micronaut.mqtt/mqttv5/native-image.properties
+++ b/mqttv5/src/main/resources/META-INF/native-image/io.micronaut.mqtt/mqttv5/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.mqtt.v5.client.health.$MqttHealthIndicator$Definition


### PR DESCRIPTION
This PR fixes the following GraalVM warnings:

```
Warning: class initialization of class io.micronaut.mqtt.v3.client.health.$MqttHealthIndicator$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/management/health/indicator/HealthIndicator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.mqtt.v3.client.health.$MqttHealthIndicator$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.mqtt.v5.client.health.$MqttHealthIndicator$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/management/health/indicator/HealthIndicator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.mqtt.v5.client.health.$MqttHealthIndicator$Definition to explicitly request delayed initialization of this class.
```