### PR TITLE
doc: mqtt.enabled in Configuration Reference

### DIFF
--- a/mqtt-core/src/main/java/io/micronaut/mqtt/config/MqttConfiguration.java
+++ b/mqtt-core/src/main/java/io/micronaut/mqtt/config/MqttConfiguration.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * MQTT V5 implementation.
- */
-@Configuration
-@Requires(property = MqttConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
-package io.micronaut.mqtt.v5;
+package io.micronaut.mqtt.config;
 
-import io.micronaut.context.annotation.Configuration;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;
-import io.micronaut.mqtt.config.MqttConfigurationProperties;
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * MQTT related configuration.
+ * @author Sergio del Amo
+ * @since 2.2.0
+ */
+public interface MqttConfiguration extends Toggleable  {
+}

--- a/mqtt-core/src/main/java/io/micronaut/mqtt/config/MqttConfigurationProperties.java
+++ b/mqtt-core/src/main/java/io/micronaut/mqtt/config/MqttConfigurationProperties.java
@@ -29,7 +29,6 @@ public class MqttConfigurationProperties implements MqttConfiguration {
     /**
      * The default enable value.
      */
-    @SuppressWarnings("WeakerAccess")
     private static final boolean DEFAULT_ENABLED = true;
 
     private boolean enabled = DEFAULT_ENABLED;

--- a/mqtt-core/src/main/java/io/micronaut/mqtt/config/MqttConfigurationProperties.java
+++ b/mqtt-core/src/main/java/io/micronaut/mqtt/config/MqttConfigurationProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mqtt.config;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} implementation for {@link MqttConfiguration}.
+ * @author Sergio del Amo
+ * @since 2.2.0
+ */
+@ConfigurationProperties(MqttConfigurationProperties.PREFIX)
+public class MqttConfigurationProperties implements MqttConfiguration {
+    public static final String PREFIX = "mqtt";
+
+    /**
+     * The default enable value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    private static final boolean DEFAULT_ENABLED = true;
+
+    private boolean enabled = DEFAULT_ENABLED;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables Micronaut MQTT integration. Default value {@value #DEFAULT_ENABLED}
+     * @param enabled True if it is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/mqtt-core/src/test/groovy/io/micronaut/mqtt/config/MqttConfigurationSpec.groovy
+++ b/mqtt-core/src/test/groovy/io/micronaut/mqtt/config/MqttConfigurationSpec.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.mqtt.config
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class MqttConfigurationSpec extends Specification {
+    @Inject
+    MqttConfiguration mqttConfiguration
+    void "mqtt is enabled by default"() {
+        expect:
+        mqttConfiguration.enabled
+    }
+}

--- a/mqtt-core/src/test/resources/logback.xml
+++ b/mqtt-core/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/mqttv3/src/main/java/io/micronaut/mqtt/v3/package-info.java
+++ b/mqttv3/src/main/java/io/micronaut/mqtt/v3/package-info.java
@@ -17,9 +17,10 @@
  * MQTT V3 implementation.
  */
 @Configuration
-@Requires(property = "mqtt.enabled", notEquals = StringUtils.FALSE)
+@Requires(property = MqttConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 package io.micronaut.mqtt.v3;
 
 import io.micronaut.context.annotation.Configuration;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.mqtt.config.MqttConfigurationProperties;


### PR DESCRIPTION
It adds a `ConfigurationProperties` object to include the section Configuration Reference of the docs. 

<img width="1146" alt="Screenshot 2022-03-05 at 22 55 39" src="https://user-images.githubusercontent.com/864788/156901122-f16d9e21-7594-479e-a70d-783468c2e7a1.png">
