### PR TITLE
migrate build plugins to 6.1.1

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,11 +96,13 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="excludeScope" value="private"/>
+            <property name="accessModifiers" value="public, protected"/>
         </module>
         <module name="JavadocType"/>
         <module name="JavadocStyle"/>
-        <module name="MissingJavadocType"/>
+        <module name="MissingJavadocType">
+            <property name="severity" value="warning"/>
+        </module>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/config_naming.html -->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,13 +15,11 @@ managed-paho-mqttv3-client = { module = "org.eclipse.paho:org.eclipse.paho.clien
 managed-paho-mqttv5-client = { module = "org.eclipse.paho:org.eclipse.paho.mqttv5.client", version.ref = "managed-mqttv5" }
 
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
-micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "micronaut-test" }
 
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bcpkix-jdk15on" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
-reactor-core = { module = "io.projectreactor:reactor-core" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 testcontainers-spock = { module = "org.testcontainers:spock", version.ref = "testcontainers" }
 

--- a/mqtt-core/build.gradle
+++ b/mqtt-core/build.gradle
@@ -8,6 +8,6 @@ dependencies {
     api(mn.micronaut.runtime)
     api(mn.micronaut.messaging)
     implementation(mnSerde.micronaut.serde.jackson)
-    implementation(libs.reactor.core)
+    implementation(mn.reactor)
     compileOnly(libs.kotlin.stdlib.jdk8)
 }

--- a/mqttv3/build.gradle
+++ b/mqttv3/build.gradle
@@ -4,9 +4,9 @@ plugins {
 
 dependencies {
     api(libs.managed.paho.mqttv3.client)
-    api project(":mqtt-core")
+    api projects.mqttCore
     compileOnly(mn.micronaut.management)
     testImplementation(mn.micronaut.management)
-    testImplementation(libs.reactor.core)
-    testImplementation(project(":test-suite-utils"))
+    testImplementation(mn.reactor)
+    testImplementation(projects.testSuiteUtils)
 }

--- a/mqttv5/build.gradle
+++ b/mqttv5/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     api projects.mqttCore
     compileOnly(mn.micronaut.management)
     testImplementation(mn.micronaut.management)
-    testImplementation(libs.reactor.core)
+    testImplementation(mn.reactor)
     testImplementation(projects.testSuiteUtils)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.1.0"
+    id("io.micronaut.build.shared.settings") version "6.1.1"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
@@ -23,16 +23,8 @@ include 'test-suite-groovy'
 include 'test-suite'
 include 'test-suite-kotlin'
 
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
-    }
-}
-
 micronautBuild {
     addSnapshotRepository()
     importMicronautCatalog()
     importMicronautCatalog("micronaut-serde")
-    importMicronautCatalog("micronaut-test")
 }

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -13,8 +13,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
-}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/mqtt/docs/custom/type/ProductInfo.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/mqtt/docs/custom/type/ProductInfo.groovy
@@ -8,14 +8,14 @@ class ProductInfo {
 
     private String size
     private Long count
-    private Boolean sealed
+    private Boolean seal
 
     ProductInfo(@Nullable String size, // <1>
                 @NonNull Long count, // <2>
-                @NonNull Boolean sealed) { // <3>
+                @NonNull Boolean seal) { // <3>
         this.size = size
         this.count = count
-        this.sealed = sealed
+        this.seal = seal
     }
 
     String getSize() {
@@ -27,7 +27,7 @@ class ProductInfo {
     }
 
     Boolean getSealed() {
-        sealed
+        seal
     }
 }
 // end::clazz[]

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -26,8 +26,3 @@ compileTestKotlin {
         javaParameters = true
     }
 }
-
-java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
-}

--- a/test-suite-utils/build.gradle
+++ b/test-suite-utils/build.gradle
@@ -12,8 +12,3 @@ dependencies {
     api projects.mqttCore
     api(libs.testcontainers.spock)
 }
-
-java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
-}

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -22,8 +22,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
-}


### PR DESCRIPTION
- Migrate build plugins to 6.1.1
- Fix illegal use of `sealed` property name in Groovy (`sealed` is a keyword as of 4.x)