### PR TITLE
Bugfix WillMessage in HiveMqttClient

### DIFF
--- a/mqtt-hivemq/src/main/java/io/micronaut/mqtt/hivemq/v5/client/Mqtt5ClientFactory.java
+++ b/mqtt-hivemq/src/main/java/io/micronaut/mqtt/hivemq/v5/client/Mqtt5ClientFactory.java
@@ -113,7 +113,8 @@ public final class Mqtt5ClientFactory implements MqttClientFactory {
                 .topic(willMessage.getTopic())
                 .payload(willMessage.getPayload())
                 .qos(Objects.requireNonNull(MqttQos.fromCode(willMessage.getQos())))
-                .retain(willMessage.isRetained());
+                .retain(willMessage.isRetained())
+                .applyWillPublish();
         }
 
         final var client = clientBuilder.buildAsync();

--- a/mqtt-hivemq/src/test/groovy/io/micronaut/mqtt/hivemq/v5/client/V5WillMessageSpec.groovy
+++ b/mqtt-hivemq/src/test/groovy/io/micronaut/mqtt/hivemq/v5/client/V5WillMessageSpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.mqtt.hivemq.v5.client
+
+
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
+import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
+import io.micronaut.mqtt.annotation.MqttSubscriber
+import io.micronaut.mqtt.annotation.Topic
+import io.micronaut.mqtt.test.AbstractMQTTTest
+import io.micronaut.mqtt.test.MQTT5Test
+import spock.util.concurrent.PollingConditions
+
+class V5WillMessageSpec extends AbstractMQTTTest implements MQTT5Test {
+
+    void "test will message"() {
+        ApplicationContext ctx = startContext([
+                "mqtt.client.will-message.payload":"last will",
+                "mqtt.client.will-message.retained":true,
+                "mqtt.client.will-message.topic":"will/topic",
+                "mqtt.client.automatically-reconnect":true,
+                "willmessagetest": true])
+        def client = ctx.getBean(Mqtt5AsyncClient)
+        def subscriber = ctx.getBean(LastWillSubscriber)
+        def polling = new PollingConditions(timeout: 3)
+
+        when:
+        client.disconnectWith()
+                .reasonCode(Mqtt5DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE) // send the will message
+                .sessionExpiryInterval(0)                                           // we want to clear the session
+                .send();
+
+        then:
+        polling.eventually {
+            assert subscriber.payload == "last will"
+        }
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Requires(property = "willmessagetest", value = StringUtils.TRUE)
+    @MqttSubscriber
+    static class LastWillSubscriber {
+
+        String payload
+
+        @Topic("will/topic")
+        void get(String payload) {
+            this.payload = payload
+        }
+    }
+}

--- a/mqtt-hivemq/src/test/groovy/io/micronaut/mqtt/hivemq/v5/client/V5WillMessageSpec.groovy
+++ b/mqtt-hivemq/src/test/groovy/io/micronaut/mqtt/hivemq/v5/client/V5WillMessageSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.mqtt.hivemq.v5.client
 
-
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode
 import io.micronaut.context.ApplicationContext
@@ -15,21 +14,28 @@ import spock.util.concurrent.PollingConditions
 class V5WillMessageSpec extends AbstractMQTTTest implements MQTT5Test {
 
     void "test will message"() {
+        // we create first application context that is going to disconnect.
         ApplicationContext ctx = startContext([
                 "mqtt.client.will-message.payload":"last will",
                 "mqtt.client.will-message.retained":true,
                 "mqtt.client.will-message.topic":"will/topic",
-                "mqtt.client.automatically-reconnect":true,
-                "willmessagetest": true])
+                ])
         def client = ctx.getBean(Mqtt5AsyncClient)
-        def subscriber = ctx.getBean(LastWillSubscriber)
         def polling = new PollingConditions(timeout: 3)
+
+        // second application is going to subscribe to the will message topic
+        // and track it to see if it gets published when first application disconnects
+        ApplicationContext ctx2 = startContext([
+                "willmessagetest": true])
+        def subscriber = ctx2.getBean(LastWillSubscriber)
+
 
         when:
         client.disconnectWith()
                 .reasonCode(Mqtt5DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE) // send the will message
                 .sessionExpiryInterval(0)                                           // we want to clear the session
-                .send();
+                .send()
+
 
         then:
         polling.eventually {
@@ -38,6 +44,7 @@ class V5WillMessageSpec extends AbstractMQTTTest implements MQTT5Test {
 
         cleanup:
         ctx.close()
+        ctx2.close()
     }
 
     @Requires(property = "willmessagetest", value = StringUtils.TRUE)


### PR DESCRIPTION
Adding applyWillPublish() method at the end of the willMessageBuilder to make sure changes are published with the connect message.

Ref example here: https://github.com/hivemq/hivemq-mqtt-client/blob/bb5dee551e1e19edbc4d6a9b19037a616a05db4f/examples/src/main/java/com/hivemq/client/mqtt/examples/Mqtt5Features.java